### PR TITLE
Stays in guided if looses rc but receiving sp >.3Hz

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -291,6 +291,7 @@ private:
         uint8_t gcs                 : 1; // 4   // A status flag for the ground station failsafe
         uint8_t ekf                 : 1; // 5   // true if ekf failsafe has occurred
         uint8_t gps_glitch          : 1; // 6   // true if gps glitch failsafe has occurred
+        uint8_t guided_sp_expired   : 1; // 7   // true if the setpoint used by guided has expired
 
         int8_t radio_counter;            // number of iterations with throttle below throttle_fs_value
 

--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -230,6 +230,10 @@ void Copter::guided_set_angle(const Quaternion &q, float climb_rate_cms)
 // should be called at 100hz or more
 void Copter::guided_run()
 {
+
+    // reset the guided mode exit flag
+    failsafe.guided_sp_expired = false;
+
     // call the correct auto controller
     switch (guided_mode) {
 
@@ -258,6 +262,11 @@ void Copter::guided_run()
         guided_angle_control_run();
         break;
     }
+    
+    if (failsafe.guided_sp_expired && failsafe.radio) {
+        failsafe_radio_on_event();
+    }
+
  }
 
 // guided_takeoff_run - takeoff in guided mode
@@ -363,10 +372,10 @@ void Copter::guided_vel_control_run()
         }
     }
 
-    // set velocity to zero if no updates received for 3 seconds
+    // exit guided if no updates received for 3 seconds
     uint32_t tnow = millis();
     if (tnow - vel_update_time_ms > GUIDED_POSVEL_TIMEOUT_MS && !pos_control.get_desired_velocity().is_zero()) {
-        pos_control.set_desired_velocity(Vector3f(0,0,0));
+        failsafe.guided_sp_expired = true;
     }
 
     // call velocity controller which includes z axis controller
@@ -412,10 +421,10 @@ void Copter::guided_posvel_control_run()
         }
     }
 
-    // set velocity to zero if no updates received for 3 seconds
+    // exit guided if no updates received for 3 seconds
     uint32_t tnow = millis();
     if (tnow - posvel_update_time_ms > GUIDED_POSVEL_TIMEOUT_MS && !posvel_vel_target_cms.is_zero()) {
-        posvel_vel_target_cms.zero();
+        failsafe.guided_sp_expired = true;
     }
 
     // calculate dt
@@ -486,12 +495,10 @@ void Copter::guided_angle_control_run()
     // constrain climb rate
     float climb_rate_cms = constrain_float(guided_angle_state.climb_rate_cms, -fabs(wp_nav.get_speed_down()), wp_nav.get_speed_up());
 
-    // check for timeout - set lean angles and climb rate to zero if no updates received for 3 seconds
+    // check for timeout - exit guided if no updates received for 3 seconds
     uint32_t tnow = millis();
     if (tnow - guided_angle_state.update_time_ms > GUIDED_ATTITUDE_TIMEOUT_MS) {
-        roll_in = 0.0f;
-        pitch_in = 0.0f;
-        climb_rate_cms = 0.0f;
+        failsafe.guided_sp_expired = true;
     }
 
     // call attitude controller

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -16,8 +16,8 @@ void Copter::failsafe_radio_on_event()
     if (should_disarm_on_failsafe()) {
         init_disarm_motors();
     } else {
-        if (control_mode == AUTO && g.failsafe_throttle == FS_THR_ENABLED_CONTINUE_MISSION) {
-            // continue mission
+        if ((control_mode == AUTO || (control_mode == GUIDED && !failsafe.guided_sp_expired)) && g.failsafe_throttle == FS_THR_ENABLED_CONTINUE_MISSION) {
+            // continue mission or guided mode
         } else if (control_mode == LAND && g.failsafe_battery_enabled == FS_BATT_LAND && failsafe.battery) {
             // continue landing
         } else {


### PR DESCRIPTION
If you set the parameter [FS_THR_ENABLE = 2](http://ardupilot.org/copter/docs/parameters.html#fs-thr-enable-throttle-failsafe-enable) the copter will stay in guided mode even if it looses RC. If guided mode is using velocity, posvel or attitude, it will exit if it doesn't receive any new setpoint in 3 seconds. Current default behavior is to RTL (or LAND if that's unsuccessful).
