### PR TITLE
GCS: HOME_POSITION scale fix; AHRS_NavEKF: SITL build issue fix

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -623,7 +623,7 @@ bool AP_AHRS_NavEKF::get_relative_position_NED(Vector3f &vec) const
     case EKF_TYPE1:
     default: {
         Vector2f posNE;
-        float posD;
+        float posD = 0;
         bool position_is_valid = (EKF1.getPosNE(posNE) && EKF1.getPosD(posD));
         vec.x = posNE.x;
         vec.y = posNE.y;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1440,7 +1440,7 @@ void GCS_MAVLINK::send_home_all(const Location &home)
                     chan,
                     home.lat,
                     home.lng,
-                    home.alt / 100,
+                    home.alt * 10,
                     0.0f, 0.0f, 0.0f,
                     q,
                     0.0f, 0.0f, 0.0f);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1422,7 +1422,7 @@ void GCS_MAVLINK::send_home(const Location &home) const
             chan,
             home.lat,
             home.lng,
-            home.alt / 100,
+            home.alt * 10,
             0.0f, 0.0f, 0.0f,
             q,
             0.0f, 0.0f, 0.0f);


### PR DESCRIPTION
- Scale home altitude to millimeters per Mavlink HOME_POSITION specification
- add explicit initialization of a variable to avoid breaking SITL build on OS X
